### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/devops-workflow.yml
+++ b/.github/workflows/devops-workflow.yml
@@ -53,7 +53,7 @@ jobs:
       run: |
           az keyvault create --resource-group ${{ env.RESOURCEGROUPNAME }} --name ${{ env.KEYVAULTNAME }}
           az keyvault secret set --vault-name ${{ env.KEYVAULTNAME }} --name test-secret --value test-secret-value
-          echo "::set-output name=object_id::`az aks show -g ${{ env.RESOURCEGROUPNAME }}  -n ${{ env.CLUSTERNAME }} --query identityProfile.kubeletidentity.objectId`"
+          echo "object_id=`az aks show -g ${{ env.RESOURCEGROUPNAME }}  -n ${{ env.CLUSTERNAME }} --query identityProfile.kubeletidentity.objectId`" >> "$GITHUB_OUTPUT"
           echo "::add-mask::`az aks show -g ${{ env.RESOURCEGROUPNAME }}  -n ${{ env.CLUSTERNAME }} --query identityProfile.kubeletidentity.objectId`"
           
     - name: Set Azure Key Vault policy
@@ -65,8 +65,8 @@ jobs:
       id: createACR
       run: |
           az acr create -n ${{ env.REGISTRYNAME }} -g ${{ env.RESOURCEGROUPNAME }} --location "${{env.REGISTRYLOCATION}}" --sku ${{env.REGISTRYSKU}} --admin-enabled
-          echo "::set-output name=acr_username::`az acr credential show -n ${{ env.REGISTRYNAME }} --query username`"
-          echo "::set-output name=acr_password::`az acr credential show -n ${{ env.REGISTRYNAME }} --query passwords[0].value`"
+          echo "acr_username=`az acr credential show -n ${{ env.REGISTRYNAME }} --query username`" >> "$GITHUB_OUTPUT"
+          echo "acr_password=`az acr credential show -n ${{ env.REGISTRYNAME }} --query passwords[0].value`" >> "$GITHUB_OUTPUT"
           echo "::add-mask::`az acr credential show -n ${{ env.REGISTRYNAME }} --query passwords[0].value`"
 
     - name: Build and push image to ACR
@@ -113,7 +113,7 @@ jobs:
     - name: Get User Assigned Managed Identity
       id: getUserAssignedIdentity
       run: |
-          echo "::set-output name=user_assigned_identity::`az aks show -g ${{ env.RESOURCEGROUPNAME }}  -n ${{ env.CLUSTERNAME }} --query identityProfile.kubeletidentity.clientId`"
+          echo "user_assigned_identity=`az aks show -g ${{ env.RESOURCEGROUPNAME }}  -n ${{ env.CLUSTERNAME }} --query identityProfile.kubeletidentity.clientId`" >> "$GITHUB_OUTPUT"
           echo "::add-mask::`az aks show -g ${{ env.RESOURCEGROUPNAME }}  -n ${{ env.CLUSTERNAME }} --query identityProfile.kubeletidentity.clientId`"
 
     - uses: azure/k8s-bake@v1
@@ -139,8 +139,8 @@ jobs:
     - name: Get ACR credentials
       id: getACRCred
       run: |
-           echo "::set-output name=acr_username::`az acr credential show -n ${{ env.REGISTRYNAME }} --query username | xargs`"
-           echo "::set-output name=acr_password::`az acr credential show -n ${{ env.REGISTRYNAME }} --query passwords[0].value | xargs`"
+           echo "acr_username=`az acr credential show -n ${{ env.REGISTRYNAME }} --query username | xargs`" >> "$GITHUB_OUTPUT"
+           echo "acr_password=`az acr credential show -n ${{ env.REGISTRYNAME }} --query passwords[0].value | xargs`" >> "$GITHUB_OUTPUT"
            echo "::add-mask::`az acr credential show -n ${{ env.REGISTRYNAME }} --query passwords[0].value | xargs`"
 
     - uses: azure/k8s-create-secret@v1
@@ -154,7 +154,7 @@ jobs:
     - name: Fetch Application insights key
       id: GetAppInsightsKey
       run: |
-        echo "::set-output name=AIKey::`az resource show -g ${{ env.RESOURCEGROUPNAME }} -n ${{ env.CLUSTERNAME }} --resource-type "Microsoft.Insights/components" --query "properties.InstrumentationKey" -o tsv`"
+        echo "AIKey=`az resource show -g ${{ env.RESOURCEGROUPNAME }} -n ${{ env.CLUSTERNAME }} --resource-type "Microsoft.Insights/components" --query "properties.InstrumentationKey" -o tsv`" >> "$GITHUB_OUTPUT"
         echo "::add-mask::`az resource show -g ${{ env.RESOURCEGROUPNAME }} -n ${{ env.CLUSTERNAME }} --resource-type "Microsoft.Insights/components" --query "properties.InstrumentationKey" -o tsv`"
 
     - uses: azure/k8s-bake@v1


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter